### PR TITLE
Add dataspec loader util

### DIFF
--- a/bela/common/policies/make.py
+++ b/bela/common/policies/make.py
@@ -11,6 +11,7 @@ from rich.pretty import pprint
 import torch
 import tyro
 
+from bela.common.datasets.util import load_dataspec
 from bela.typ import Head, HeadSpec, Morph
 
 
@@ -35,27 +36,7 @@ from bela.common.policies.bela import BELAPolicy
 
 
 def make_policy():
-    batchspec = {
-        "observation": {
-            "robot": {
-                "joints": PolicyFeature(FeatureType.STATE, (7,)),
-                "image.side": PolicyFeature(FeatureType.VISUAL, (3, 480, 640)),
-                "image.wrist": PolicyFeature(FeatureType.VISUAL, (3, 480, 640)),
-                # "pose": PolicyFeature(FeatureType.STATE, (6,)),
-                # "gripper": PolicyFeature(FeatureType.STATE, (1,)),
-            },
-            "human": {
-                # "gripper": PolicyFeature(FeatureType.STATE, (1,)),
-                "mano.hand_pose": PolicyFeature(FeatureType.STATE, (15, 3)),  # (15, 3, 3)),
-                "mano.global_orient": PolicyFeature(FeatureType.STATE, (3,)),  # (3, 3)),
-                "kp3d": PolicyFeature(FeatureType.STATE, (21, 3)),
-            },
-            "shared": {
-                "image.low": PolicyFeature(FeatureType.VISUAL, (3, 480, 640)),
-                "cam.pose": PolicyFeature(FeatureType.STATE, (6,)),
-            },
-        },
-    }
+    batchspec = load_dataspec()
 
     def flatten_state_feat(x):
         if x.type == FeatureType.STATE:

--- a/bela/scripts/train.py
+++ b/bela/scripts/train.py
@@ -26,7 +26,6 @@ from lerobot.common.utils.wandb_utils import WandBLogger
 from lerobot.configs.default import DatasetConfig, WandBConfig
 from lerobot.configs.policies import PreTrainedConfig
 from lerobot.configs.train import TrainPipelineConfig
-from lerobot.configs.types import FeatureType, PolicyFeature
 from lerobot.scripts.eval import eval_policy
 
 #
@@ -39,7 +38,7 @@ from torch.utils.data.distributed import DistributedSampler
 import tyro
 
 import bela
-from bela.common.datasets.util import DataStats, postprocess
+from bela.common.datasets.util import DataStats, load_dataspec, postprocess
 import bela.train_tools as tt
 from bela.util import spec
 
@@ -138,27 +137,7 @@ def main(cfg: MyTrainConfig):
 
         # dataset = bela.common.dataset.make_dataset(cfg)  # dataset = make_dataset(cfg)
 
-        batchspec = {
-            "observation": {
-                "robot": {
-                    "joints": PolicyFeature(FeatureType.STATE, (7,)),
-                    "image.side": PolicyFeature(FeatureType.VISUAL, (3, 480, 640)),
-                    "image.wrist": PolicyFeature(FeatureType.VISUAL, (3, 480, 640)),
-                    # "pose": PolicyFeature(FeatureType.STATE, (6,)),
-                    "gripper": PolicyFeature(FeatureType.STATE, (1,)),
-                },
-                "human": {
-                    # "gripper": PolicyFeature(FeatureType.STATE, (1,)),
-                    "mano.hand_pose": PolicyFeature(FeatureType.STATE, (15, 3)),  # (15, 3, 3)),
-                    # "mano.global_orient": PolicyFeature( FeatureType.STATE, (3,)),  # (3, 3)),
-                    "kp3d": PolicyFeature(FeatureType.STATE, (21, 3)),
-                },
-                "shared": {
-                    "image.low": PolicyFeature(FeatureType.VISUAL, (3, 480, 640)),
-                    "cam.pose": PolicyFeature(FeatureType.STATE, (6,)),
-                },
-            },
-        }
+        batchspec = load_dataspec()
         batchspec = flatten_dict(batchspec, sep=".")
         sharespec = {k: v for k, v in batchspec.items() if k.startswith("observation.shared")}
 

--- a/dataspec.json
+++ b/dataspec.json
@@ -1,0 +1,18 @@
+{
+  "observation": {
+    "robot": {
+      "joints": {"type": "STATE", "shape": [7]},
+      "image.side": {"type": "VISUAL", "shape": [3, 480, 640]},
+      "image.wrist": {"type": "VISUAL", "shape": [3, 480, 640]}
+    },
+    "human": {
+      "mano.hand_pose": {"type": "STATE", "shape": [15, 3]},
+      "mano.global_orient": {"type": "STATE", "shape": [3]},
+      "kp3d": {"type": "STATE", "shape": [21, 3]}
+    },
+    "shared": {
+      "image.low": {"type": "VISUAL", "shape": [3, 480, 640]},
+      "cam.pose": {"type": "STATE", "shape": [6]}
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `dataspec.json` to define observation features
- implement `load_dataspec` helper in dataset util
- use the dataspec in policy creation and training scripts

## Testing
- `ruff check bela/common/datasets/util.py bela/common/policies/make.py bela/scripts/train.py`
